### PR TITLE
Add option to use openAIGym without pygame rendering

### DIFF
--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -134,11 +134,11 @@ class SnakeGameGym(SnakeGame):
 		body_collision = self.check_body_collision()		
 		
 		if fruit_collision:
-			return 10
+			return 1
 		elif wall_collision or body_collision:
-			return -10
-		else:
 			return -1
+		else:
+			return 0
 
 	def check_fruit_collision(self) -> bool:
 		"""

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -35,7 +35,7 @@ class SnakeGameGym(SnakeGame):
 		self.grid_start_y = 100
 		self.play = True
 		self.restart = False
-		self.fps = fps
+		self.fps = fps  # FIXME: remove fps since it doesn't seem to be doing anything
 		self.rows = 10
 		self.cols = self.rows
 		self.snake = Snake(self.rows,self.cols)

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -29,14 +29,12 @@ class SnakeGameGym(SnakeGame):
 			2: "right",
 			3: "down",
 		}
-
+		
 		self.width = 500
 		self.height = 600
 		self.grid_start_y = 100
-		self.win = pygame.display.set_mode((self.width, self.height))
 		self.play = True
 		self.restart = False
-		self.clock = pygame.time.Clock()
 		self.fps = fps
 		self.rows = 10
 		self.cols = self.rows
@@ -45,6 +43,10 @@ class SnakeGameGym(SnakeGame):
 		self.generate_fruit()
 		self.score = 0
 		self.high_score = 0	
+
+		if self.use_pygame:
+			self.win = pygame.display.set_mode((self.width, self.height))
+			self.clock = pygame.time.Clock()
 
 
 	def pos_on_board(self, pos):

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -8,6 +8,8 @@ import numpy as np
 from gym import spaces
 from gym_snake.envs.snakeGame import SnakeGame
 from gym_snake.envs.snake import Snake
+import pygame
+
 
 class SnakeGameGym(SnakeGame):
 	"""
@@ -16,10 +18,11 @@ class SnakeGameGym(SnakeGame):
 	Inherits the SankeGame class that runs the Snake Game.
 	"""
 
-	def __init__(self, fps: int):
+	def __init__(self, fps: int, use_pygame: bool = True):
 		"""
 		Initializes the SnakeGameGATest class.
 		"""
+		self.use_pygame = use_pygame
 		self.move_map = {
 			0: "left",
 			1: "up",
@@ -27,8 +30,23 @@ class SnakeGameGym(SnakeGame):
 			3: "down",
 		}
 
-		super().__init__(fps)
-	
+		self.width = 500
+		self.height = 600
+		self.grid_start_y = 100
+		self.win = pygame.display.set_mode((self.width, self.height))
+		self.play = True
+		self.restart = False
+		self.clock = pygame.time.Clock()
+		self.fps = fps
+		self.rows = 10
+		self.cols = self.rows
+		self.snake = Snake(self.rows,self.cols)
+		self.fruit_pos = (0,0)
+		self.generate_fruit()
+		self.score = 0
+		self.high_score = 0	
+
+
 	def pos_on_board(self, pos):
 		# If row index is less than 0 or greater than number of rows, pos is not on board
 		if pos[0] < 0 or pos[0] >= self.rows:
@@ -114,11 +132,11 @@ class SnakeGameGym(SnakeGame):
 		body_collision = self.check_body_collision()		
 		
 		if fruit_collision:
-			return 1
+			return 10
 		elif wall_collision or body_collision:
-			return -1
+			return -10
 		else:
-			return 0
+			return -1
 
 	def check_fruit_collision(self) -> bool:
 		"""

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -31,7 +31,7 @@ class SnakeEnv(gym.Env):
         # If there was a fruit collision during last frame, move the fruit.
         if self.game.check_fruit_collision():
             self.game.respond_to_fruit_consumption()
-        self.game.clock.tick(self.game.fps)
+        
         self.game.move_snake(action)
     
         # Get observation after move
@@ -43,7 +43,9 @@ class SnakeEnv(gym.Env):
         # Game is over if wall collision or body collision occurred. TODO: add end done for time limit
         done = self.game.check_wall_collision() or self.game.check_body_collision()
         
-        self.game.redraw_window()
+        if self.game.use_pygame:
+            self.game.clock.tick(self.game.fps)
+            self.game.redraw_window()
 
         info = {"episode": None}  # FIXME: Figure out what to do with info. stable_baseline3 seems to require episode object
 

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -9,14 +9,17 @@ from gym_snake.envs.snakeGameGym import *
 class SnakeEnv(gym.Env):
     metadata = {'render.modes': ['human']}
 
-    def __init__(self):
+    def __init__(self, use_pygame: bool = True):
         fps = 3000
         self.viewer = None
-        self.game = SnakeGameGym(fps)
+
+        if use_pygame:
+            pygame.font.init()
+        self.game = SnakeGameGym(fps, use_pygame=use_pygame)
 
         self.action_space = spaces.Discrete(4)
         self.observation_space = spaces.Box(low=0, high=3, shape=(self.game.cols, self.game.rows), dtype=int)
-        pygame.font.init()   
+           
 
 
     def step(self, action: spaces.Discrete(4)) -> tuple:


### PR DESCRIPTION
I got the idea that we could really improve performance if we got rid of pygame. So I added an argument to the init of the snake env. Turns out, the efficiency gains are significant!

We see that training and testing occurs about 4.6 times faster when pygame is not being used:
<img width="572" alt="Screen Shot 2021-11-01 at 12 35 44 AM" src="https://user-images.githubusercontent.com/19896216/139637436-5f81e9ee-cc00-4115-9ec8-c966491b7a66.png">

From the couple times that I timed it, the efficiency gains ranged from 3-9x

## Why is this important?
- Faster training means we can try more things in less time
- Will encounter fewer bugs when trying to run this on the server
 