### PR TITLE
Implement game variable for SnakeGameGym env

### DIFF
--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -18,10 +18,15 @@ class SnakeGameGym(SnakeGame):
 	Inherits the SankeGame class that runs the Snake Game.
 	"""
 
-	def __init__(self, fps: int, use_pygame: bool = True):
+	def __init__(self,
+		board_height: int = 10, 
+		board_width:int = 10, 
+		use_pygame: bool = True, 
+		game_speed: str = "observable"):
 		"""
-		Initializes the SnakeGameGATest class.
+		Initializes the SnakeGameGym class.
 		"""
+		# SnakeGameGym specific instance variables
 		self.use_pygame = use_pygame
 		self.move_map = {
 			0: "left",
@@ -29,24 +34,35 @@ class SnakeGameGym(SnakeGame):
 			2: "right",
 			3: "down",
 		}
+		self.game_speeds = {
+			"playable": 8,
+			"observable": 25,
+			"lightspeed": 3000
+		}
 		
+		# original Snake instance variables
 		self.width = 500
 		self.height = 600
 		self.grid_start_y = 100
 		self.play = True
 		self.restart = False
-		self.fps = fps  # FIXME: remove fps since it doesn't seem to be doing anything
-		self.rows = 10
-		self.cols = self.rows
+		self.rows = board_height
+		self.cols = board_width
 		self.snake = Snake(self.rows,self.cols)
-		self.fruit_pos = (0,0)
-		self.generate_fruit()
+		self.fruit_pos = self.generate_fruit()
 		self.score = 0
 		self.high_score = 0	
 
+		# initializing pygame visualization
 		if self.use_pygame:
 			self.win = pygame.display.set_mode((self.width, self.height))
 			self.clock = pygame.time.Clock()
+
+			# set frame update speeds
+			if game_speed in self.game_speeds:
+				self.fps = self.game_speeds[game_speed]
+			else:
+				self.fps = self.game_speeds["observable"]
 
 
 	def pos_on_board(self, pos):

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -19,12 +19,17 @@ class SnakeGameGym(SnakeGame):
 	"""
 
 	def __init__(self,
-		board_height: int = 10, 
-		board_width:int = 10, 
-		use_pygame: bool = True, 
-		game_speed: str = "observable"):
+		board_height: int, 
+		board_width:int, 
+		use_pygame: bool, 
+		game_speed: str):
 		"""
 		Initializes the SnakeGameGym class.
+
+		board_height: the number of rows on the game board.
+		board_width: the number of columns on the game board.
+		use_pygame: boolean flag for whether or not to visualize the environment with pygame.
+		game_speed: sets the speed of the game, valid options are 'playable', 'observable', and 'lightspeed'.
 		"""
 		# SnakeGameGym specific instance variables
 		self.use_pygame = use_pygame

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -49,7 +49,8 @@ class SnakeGameGym(SnakeGame):
 		self.rows = board_height
 		self.cols = board_width
 		self.snake = Snake(self.rows,self.cols)
-		self.fruit_pos = self.generate_fruit()
+		self.fruit_pos = (0,0)
+		self.generate_fruit()
 		self.score = 0
 		self.high_score = 0	
 

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -47,7 +47,7 @@ class SnakeGameGym(SnakeGame):
 		self.restart = False
 		self.rows = board_height
 		self.cols = board_width
-		self.snake = Snake(self.rows,self.cols)
+		self.snake = SnakeGym(self.rows, self.cols, self.get_rand_pos())
 		self.fruit_pos = (0,0)
 		self.generate_fruit()
 		self.score = 0

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -21,15 +21,13 @@ class SnakeGameGym(SnakeGame):
 	def __init__(self,
 		board_height: int, 
 		board_width:int, 
-		use_pygame: bool, 
-		game_speed: str):
+		use_pygame: bool):
 		"""
 		Initializes the SnakeGameGym class.
 
 		board_height: the number of rows on the game board.
 		board_width: the number of columns on the game board.
 		use_pygame: boolean flag for whether or not to visualize the environment with pygame.
-		game_speed: sets the speed of the game, valid options are 'playable', 'observable', and 'lightspeed'.
 		"""
 		# SnakeGameGym specific instance variables
 		self.use_pygame = use_pygame
@@ -38,11 +36,6 @@ class SnakeGameGym(SnakeGame):
 			1: "up",
 			2: "right",
 			3: "down",
-		}
-		self.game_speeds = {
-			"playable": 8,
-			"observable": 25,
-			"lightspeed": 3000
 		}
 		
 		# original Snake instance variables
@@ -63,12 +56,6 @@ class SnakeGameGym(SnakeGame):
 		if self.use_pygame:
 			self.win = pygame.display.set_mode((self.width, self.height))
 			self.clock = pygame.time.Clock()
-
-			# set frame update speeds
-			if game_speed in self.game_speeds:
-				self.fps = self.game_speeds[game_speed]
-			else:
-				self.fps = self.game_speeds["observable"]
 
 
 	def pos_on_board(self, pos):

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -15,7 +15,7 @@ class SnakeEnv(gym.Env):
         board_height: int = 10, 
 		board_width:int = 10, 
 		use_pygame: bool = True, 
-		fps: int = 25,
+		fps: int = 3000,
         reward_func: Callable[..., float] = basic_reward_func):
         """
         Initializes the custom Snake gym environment.

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -28,13 +28,12 @@ class SnakeEnv(gym.Env):
                      int output representing a reward for the snake agent based on the inputs. 
                      Defaults to snakeRewardFunc.basic_reward_func()
         """
-        fps = 3000
         self.viewer = None
 
         if use_pygame:
             pygame.font.init()
             self.fps = fps
-        self.game = SnakeGameGym(board_height, board_width, use_pygame, fps)
+        self.game = SnakeGameGym(board_height, board_width, use_pygame)
 
         self.reward_func = reward_func
         self.action_space = spaces.Discrete(4)

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -9,13 +9,20 @@ from gym_snake.envs.snakeGameGym import *
 class SnakeEnv(gym.Env):
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, use_pygame: bool = True):
-        fps = 3000
+    def __init__(self, 
+        board_height: int = 10, 
+		board_width:int = 10, 
+		use_pygame: bool = True, 
+		game_speed: str = "observable"):
+        """
+        Initializes the custom Snake gym environment
+        """
         self.viewer = None
 
         if use_pygame:
             pygame.font.init()
-        self.game = SnakeGameGym(fps, use_pygame=use_pygame)
+        self.game = SnakeGameGym(board_height=board_height, board_width=board_width, 
+                                use_pygame=use_pygame, game_speed=game_speed)
 
         self.action_space = spaces.Discrete(4)
         self.observation_space = spaces.Box(low=0, high=3, shape=(self.game.cols, self.game.rows), dtype=int)

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -15,14 +15,18 @@ class SnakeEnv(gym.Env):
 		use_pygame: bool = True, 
 		game_speed: str = "observable"):
         """
-        Initializes the custom Snake gym environment
+        Initializes the custom Snake gym environment.
+
+		board_height: the number of rows on the game board. defaults to 10.
+		board_width: the number of columns on the game board. defaults to 10.
+		use_pygame: boolean flag for whether or not to visualize the environment with pygame. defaults to True.
+		game_speed: sets the speed of the game, valid options are 'playable', 'observable', and 'lightspeed'. defaults to 'observable'
         """
         self.viewer = None
 
         if use_pygame:
             pygame.font.init()
-        self.game = SnakeGameGym(board_height=board_height, board_width=board_width, 
-                                use_pygame=use_pygame, game_speed=game_speed)
+        self.game = SnakeGameGym(board_height, board_width, use_pygame, game_speed)
 
         self.action_space = spaces.Discrete(4)
         self.observation_space = spaces.Box(low=0, high=3, shape=(self.game.cols, self.game.rows), dtype=int)

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -13,20 +13,21 @@ class SnakeEnv(gym.Env):
         board_height: int = 10, 
 		board_width:int = 10, 
 		use_pygame: bool = True, 
-		game_speed: str = "observable"):
+		fps: int = 25):
         """
         Initializes the custom Snake gym environment.
 
 		board_height: the number of rows on the game board. defaults to 10.
 		board_width: the number of columns on the game board. defaults to 10.
 		use_pygame: boolean flag for whether or not to visualize the environment with pygame. defaults to True.
-		game_speed: sets the speed of the game, valid options are 'playable', 'observable', and 'lightspeed'. defaults to 'observable'
+		fps: sets the speed of the game in frames per second.
         """
         self.viewer = None
 
         if use_pygame:
             pygame.font.init()
-        self.game = SnakeGameGym(board_height, board_width, use_pygame, game_speed)
+            self.fps = fps
+        self.game = SnakeGameGym(board_height, board_width, use_pygame, fps)
 
         self.action_space = spaces.Discrete(4)
         self.observation_space = spaces.Box(low=0, high=3, shape=(self.game.cols, self.game.rows), dtype=int)
@@ -55,7 +56,7 @@ class SnakeEnv(gym.Env):
         done = self.game.check_wall_collision() or self.game.check_body_collision()
         
         if self.game.use_pygame:
-            self.game.clock.tick(self.game.fps)
+            self.game.clock.tick(self.fps)
             self.game.redraw_window()
 
         info = {"episode": None}  # FIXME: Figure out what to do with info. stable_baseline3 seems to require episode object

--- a/trainTestReinforcementAlgorithm.py
+++ b/trainTestReinforcementAlgorithm.py
@@ -39,13 +39,13 @@ import gym_snake.envs.snakeRewardFuncs as RewardFuncs
 
 # %%
 def trainRL(
-    train_timesteps: int,
-    env_name: str,
-    board_height: int,
-    board_width: int, 
-    visualize_training: bool,
-    visualization_fps: int, 
-    reward_function: Callable[..., float]
+    train_timesteps=1000, # Set amount of time for training. One step is one action for the snake.
+    env_name='snake-v0', # Set gym environment name.
+    board_height=10, # Set game board height.
+    board_width=10, # Set game board width.
+    visualize_training=False, # We don't want to visualize the training process.
+    visualization_fps=3000, # Default to a high value for training speed if training is visualized.
+    reward_function=RewardFuncs.basic_reward_func # Set reward function to be used in training. Reward functions are defined in snakeRewardFuncs.py
 ):
     env = gym.make(
         env_name, 
@@ -76,13 +76,13 @@ def trainRL(
 # %%
 def testRL(
     model,
-    test_timesteps: int,
-    env_name: str,
-    board_height: int,
-    board_width: int, 
-    visualize_testing: bool,
-    visualization_fps: int, 
-    reward_function: Callable[..., float]
+    test_timesteps=100, # Set amount of time for testing. One step is one action for the snake.
+    env_name='snake-v0', # Set gym environment name.
+    board_height=10, # Set game board height.
+    board_width=10, # Set game board width.
+    visualize_testing=True, # Set to true in order to see game moves in pygame. Should be false if run on server.
+    visualization_fps=30, # Set frames per second of testing visualization.
+    reward_function=RewardFuncs.basic_reward_func # Set reward function to be used in training. Reward functions are defined in snakeRewardFuncs.py
 ):
     # Setup
     env = gym.make(
@@ -139,38 +139,14 @@ def saveRL(
 
 
 # %% [markdown]
-# ## Initialize Game Variables
-# %%
-# Set amount of time for training/testing. One step is one action for the snake.
-train_timesteps=1000
-test_timesteps=100
-
-# Set gym environment name
-env_name = 'snake-v0'
-
-# Set board dimensions
-board_height = 10
-board_width = 10
-
-# Set visualization arguments
-visualize_training = False # We don't want to visualize the training process
-visualize_testing = True # Set to true in order to see game moves in pygame. Should be false if run on server.
-visualization_fps = 30
-
-# Set reward function to be used in training 
-# Reward functions are defined in snakeRewardFuncs.py
-reward_function = RewardFuncs.basic_reward_func 
-
-
-# %% [markdown]
 # ## Run in Notebook
 # To run in the notebook, uncomment the following three lines:
 
 # %%
-model = trainRL(train_timesteps, env_name, board_height, board_width, visualize_training, visualization_fps, reward_function)
-scores = testRL(model, test_timesteps, env_name, board_height, board_width, visualize_testing, visualization_fps, reward_function)
-analyzeRL(scores)
-saveRL(model)
+# model = trainRL()
+# scores = testRL(model)
+# analyzeRL(scores)
+# saveRL(model)
 
 # %% [markdown]
 # ## Run on commandline
@@ -191,7 +167,9 @@ def main():
     aparser.add_argument("--visualize_testing", type=bool, default=True)
     aparser.add_argument("--visualization_fps", type=int, default=30)
 
-    aparser.add_argument("--reward_function", type=Callable[..., float], default=RewardFuncs.basic_reward_func, help="function to determine how a snake agent is rewarded/punished for certain actions during training. Available functions can be found in snakeRewardFuncs.py")
+    # FIXME currently we are not able to pass an argument for selecting the reward function as a command line arg. 
+    # We should figure this out, but until then, change the reward function on line 181.
+    # aparser.add_argument("--reward_function", type=Callable[..., float], default=RewardFuncs.basic_reward_func, help="function to determine how a snake agent is rewarded/punished for certain actions during training. Available functions can be found in snakeRewardFuncs.py")
     
     aparser.add_argument("--print_analysis", type=bool, default=True, help="bool to determine whether or not analysis of test scores is done")    
     
@@ -199,6 +177,8 @@ def main():
     aparser.add_argument("--model_filename", type=str, default="", help="filename for model if it is saved. Should probably start with 'saved_models/' directory")        
     
     args = aparser.parse_args()
+
+    reward_function = RewardFuncs.basic_reward_func
     
     # Training
     model = trainRL(
@@ -208,7 +188,7 @@ def main():
         args.board_width,
         args.visualize_training,
         args.visualization_fps,
-        args.reward_function
+        reward_function
     )
     
     # Testing
@@ -220,7 +200,7 @@ def main():
         args.board_width,
         args.visualize_testing,
         args.visualization_fps,
-        args.reward_function)
+        reward_function)
     
     # Analysis
     if args.print_analysis:

--- a/trainTestReinforcementAlgorithm.py
+++ b/trainTestReinforcementAlgorithm.py
@@ -22,7 +22,7 @@ from stable_baselines3 import A2C
 import numpy as np
 from argparse import ArgumentParser
 from datetime import datetime
-from gym_snake.envs.snakeRewardFuncs import *
+from gym_snake.envs.snakeRewardFuncs import * as RewardFuncs
 
 
 # %% [markdown]

--- a/trainTestReinforcementAlgorithm.py
+++ b/trainTestReinforcementAlgorithm.py
@@ -22,7 +22,7 @@ from stable_baselines3 import A2C
 import numpy as np
 from argparse import ArgumentParser
 from datetime import datetime
-from gym_snake.envs.snakeRewardFuncs import * as RewardFuncs
+import gym_snake.envs.snakeRewardFuncs as RewardFuncs
 
 
 # %% [markdown]
@@ -159,7 +159,7 @@ visualization_fps = 30
 
 # Set reward function to be used in training 
 # Reward functions are defined in snakeRewardFuncs.py
-reward_function = basic_reward_func 
+reward_function = RewardFuncs.basic_reward_func 
 
 
 # %% [markdown]
@@ -191,7 +191,7 @@ def main():
     aparser.add_argument("--visualize_testing", type=bool, default=True)
     aparser.add_argument("--visualization_fps", type=int, default=30)
 
-    aparser.add_argument("--reward_function", type=Callable[..., float], default=basic_reward_func, help="function to determine how a snake agent is rewarded/punished for certain actions during training. Available functions can be found in snakeRewardFuncs.py")
+    aparser.add_argument("--reward_function", type=Callable[..., float], default=RewardFuncs.basic_reward_func, help="function to determine how a snake agent is rewarded/punished for certain actions during training. Available functions can be found in snakeRewardFuncs.py")
     
     aparser.add_argument("--print_analysis", type=bool, default=True, help="bool to determine whether or not analysis of test scores is done")    
     


### PR DESCRIPTION
This PR adds the ability to specify the following SnakeGameGym parameters: `board_height`, `board_width`, and `game_speed`. Available `game_speed` options are "playable" (8 FPS), "observable" (25 FPS), and "lightspeed" (3000) FPS.

Side note: we should update Jack's procedure PR (https://github.com/jackdavidweber/sNNakeCode/pull/7) with these new parameters, which I'm happy to do!