### PR TITLE
Kill and/or punish snake after N moves

### DIFF
--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -198,9 +198,9 @@ class SnakeGameGym(SnakeGame):
 		Function that checks whether or not the snake has made too many moves since 
 		last consuming a fruit.
 		"""
-		return (self.max_moves_no_fruit <= 0 or # non-positive allowed move count default returns true
-				self.check_fruit_collision() or # if the snake's head is in the same space as a fruit return true
-				self.num_moves_since_fruit <= self.max_moves_no_fruit) #
+		return (self.max_moves_no_fruit > 0 and # non-positive max move count default returns false
+				not self.check_fruit_collision() and # if the snake's head is in the same space as a fruit return false
+				self.num_moves_since_fruit > self.max_moves_no_fruit) #
 
 	def reset_moves_since_fruit(self) -> None:
 		"""

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -21,12 +21,15 @@ class SnakeGameGym(SnakeGame):
 	def __init__(self,
 		board_height: int, 
 		board_width:int, 
+		num_allowed_moves_since_fruit: int,
 		use_pygame: bool):
 		"""
 		Initializes the SnakeGameGym class.
 
 		board_height: the number of rows on the game board.
 		board_width: the number of columns on the game board.
+		num_allowed_moves_since_fruit: number of allowed consecutive moves that do not result in fruit consumption. 
+									   Non-positive values correspond to no limit.
 		use_pygame: boolean flag for whether or not to visualize the environment with pygame.
 		"""
 		# SnakeGameGym specific instance variables
@@ -37,6 +40,8 @@ class SnakeGameGym(SnakeGame):
 			2: "right",
 			3: "down",
 		}
+		self.num_allowed_moves_since_fruit = num_allowed_moves_since_fruit
+		self.num_moves_since_fruit = 0
 		
 		# original Snake instance variables
 		self.width = 500
@@ -172,3 +177,24 @@ class SnakeGameGym(SnakeGame):
 				return True
 
 		return False
+
+	def check_num_moves_since_fruit_valid(self) -> bool:
+		"""
+		Function that checks whether or not the snake has made too many moves since 
+		last consuming a fruit.
+		"""
+		return (self.num_allowed_moves_since_fruit <= 0 or # non-positive allowed move count default returns true
+				self.check_fruit_collision() or # if the snake's head is in the same space as a fruit return true
+				self.num_moves_since_fruit <= self.num_allowed_moves_since_fruit) #
+
+	def reset_num_current_moves_since_fruit(self) -> None:
+		"""
+		Helper function for resetting num_current_moves_since_fruit
+		"""
+		self.num_moves_since_fruit = 0
+
+	def increment_num_current_moves_since_fruit(self) -> None:
+		"""
+		Helper function for incrementing num_current_moves_since_fruit
+		"""
+		self.num_moves_since_fruit += 1

--- a/gym_snake/envs/snakeGameGym.py
+++ b/gym_snake/envs/snakeGameGym.py
@@ -22,14 +22,14 @@ class SnakeGameGym(SnakeGame):
 	def __init__(self,
 		board_height: int, 
 		board_width:int, 
-		num_allowed_moves_since_fruit: int,
+		max_moves_no_fruit: int,
 		use_pygame: bool):
 		"""
 		Initializes the SnakeGameGym class.
 
 		board_height: the number of rows on the game board.
 		board_width: the number of columns on the game board.
-		num_allowed_moves_since_fruit: number of allowed consecutive moves that do not result in fruit consumption. 
+		max_moves_no_fruit: number of allowed consecutive moves that do not result in fruit consumption. 
 									   Non-positive values correspond to no limit.
 		use_pygame: boolean flag for whether or not to visualize the environment with pygame.
 		"""
@@ -41,7 +41,7 @@ class SnakeGameGym(SnakeGame):
 			2: "right",
 			3: "down",
 		}
-		self.num_allowed_moves_since_fruit = num_allowed_moves_since_fruit
+		self.max_moves_no_fruit = max_moves_no_fruit
 		self.num_moves_since_fruit = 0
 		
 		# original Snake instance variables
@@ -184,22 +184,22 @@ class SnakeGameGym(SnakeGame):
 
 		return False
 
-	def check_num_moves_since_fruit_valid(self) -> bool:
+	def check_exceeded_max_moves(self) -> bool:
 		"""
 		Function that checks whether or not the snake has made too many moves since 
 		last consuming a fruit.
 		"""
-		return (self.num_allowed_moves_since_fruit <= 0 or # non-positive allowed move count default returns true
+		return (self.max_moves_no_fruit <= 0 or # non-positive allowed move count default returns true
 				self.check_fruit_collision() or # if the snake's head is in the same space as a fruit return true
-				self.num_moves_since_fruit <= self.num_allowed_moves_since_fruit) #
+				self.num_moves_since_fruit <= self.max_moves_no_fruit) #
 
-	def reset_num_current_moves_since_fruit(self) -> None:
+	def reset_moves_since_fruit(self) -> None:
 		"""
 		Helper function for resetting num_current_moves_since_fruit
 		"""
 		self.num_moves_since_fruit = 0
 
-	def increment_num_current_moves_since_fruit(self) -> None:
+	def increment_moves_since_fruit(self) -> None:
 		"""
 		Helper function for incrementing num_current_moves_since_fruit
 		"""

--- a/gym_snake/envs/snakeRewardFuncs.py
+++ b/gym_snake/envs/snakeRewardFuncs.py
@@ -21,3 +21,29 @@ def basic_reward_func(reward_dict) -> float:
         return -1
     else: 
         return 0
+
+
+def basic_reward_func_with_move_ceiling(reward_dict) -> float:
+    """
+    Basic reward function that rewards the snake for consuming a fruit, 
+    punishes it for colliding with itself or a wall, punishes it for running
+    out of moves after not consuming a fruit, and rewards nothing otherwise.
+
+    reward_dict:
+        did_consume_fruit: boolean representing whether a snake consumed a fruit in the last move
+        did_collide_wall: boolean representing whether a snake collided with itself in the last move
+        did_collide_body: boolean representing whether a snake collided with a wall in the last move
+        did_exceed_allowed_moves_no_fruit: boolean representing whether a snake has exceeded the number of allowable 
+                                           moves without consuming a fruit
+
+    output: 
+        a float representing a reward assigned to the snake agent based on the inputs provided
+    """
+    if reward_dict["did_consume_fruit"]:
+        return 10.0
+    elif reward_dict["did_collide_wall"] or reward_dict["did_collide_body"]:
+        return -1.0
+    elif reward_dict["did_exceed_allowed_moves_no_fruit"]:
+        return -5.0
+    else: 
+        return 0.0

--- a/gym_snake/envs/snakeRewardFuncs.py
+++ b/gym_snake/envs/snakeRewardFuncs.py
@@ -32,7 +32,7 @@ def basic_reward_func_with_move_ceiling(reward_dict) -> float:
         did_consume_fruit: boolean representing whether a snake consumed a fruit in the last move
         did_collide_wall: boolean representing whether a snake collided with itself in the last move
         did_collide_body: boolean representing whether a snake collided with a wall in the last move
-        did_exceed_allowed_moves_no_fruit: boolean representing whether a snake has exceeded the number of allowable 
+        did_exceed_max_moves_no_fruit: boolean representing whether a snake has exceeded the number of allowable 
                                            moves without consuming a fruit
 
     output: 
@@ -42,7 +42,7 @@ def basic_reward_func_with_move_ceiling(reward_dict) -> float:
         return 10.0
     elif reward_dict["did_collide_wall"] or reward_dict["did_collide_body"]:
         return -1.0
-    elif reward_dict["did_exceed_allowed_moves_no_fruit"]:
+    elif reward_dict["did_exceed_max_moves_no_fruit"]:
         return -5.0
     else: 
         return 0.0

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -66,8 +66,8 @@ class SnakeEnv(gym.Env):
         did_collide_body = self.game.check_body_collision()
         did_move_closer_to_fruit = self.game.check_closer_to_fruit()
 
-        # Check if snake is within threshold of allowable moves without consuming fruit
-        did_exceed_allowed_moves_no_fruit = not self.game.check_exceeded_max_moves()
+        # Check if snake exceeded threshold of max moves without consuming fruit
+        did_exceed_max_moves_no_fruit = self.game.check_exceeded_max_moves()
 
         # Get observation after move
         observation = self.game.get_board()
@@ -77,13 +77,13 @@ class SnakeEnv(gym.Env):
             "did_consume_fruit":did_consume_fruit,
             "did_collide_wall": did_collide_wall,
             "did_collide_body": did_collide_body,
-            "did_exceed_allowed_moves_no_fruit": did_exceed_allowed_moves_no_fruit,
+            "did_exceed_max_moves_no_fruit": did_exceed_max_moves_no_fruit,
             "did_move_closer_to_fruit": did_move_closer_to_fruit
         }
         rewards = self.reward_func(reward_dict)
 
         # Game is over if wall collision, body collision, or too many moves before consuming a fruit occurred.
-        done = did_collide_wall or did_collide_body or did_exceed_allowed_moves_no_fruit
+        done = did_collide_wall or did_collide_body or did_exceed_max_moves_no_fruit
 
         # FIXME: Figure out what to do with info. stable_baseline3 seems to require episode object
         info = {"episode": None}  

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -13,7 +13,8 @@ class SnakeEnv(gym.Env):
 
     def __init__(self, 
         board_height: int = 10, 
-		board_width:int = 10, 
+		board_width:int = 10,  
+		num_allowed_moves_since_fruit: int = 0,
 		use_pygame: bool = True, 
 		fps: int = 25,
         reward_func: Callable[..., float] = basic_reward_func):
@@ -22,6 +23,8 @@ class SnakeEnv(gym.Env):
 
 		board_height: the number of rows on the game board. defaults to 10.
 		board_width: the number of columns on the game board. defaults to 10.
+        num_allowed_moves_since_fruit: number of allowed consecutive moves that do not result in fruit consumption. 
+									   Non-positive values correspond to no limit.
 		use_pygame: boolean flag for whether or not to visualize the environment with pygame. defaults to True.
 		fps: sets the speed of the game in frames per second.
         reward_func: a function that takes any inputs (representing important game states) and returns an 
@@ -33,7 +36,7 @@ class SnakeEnv(gym.Env):
         if use_pygame:
             pygame.font.init()
             self.fps = fps
-        self.game = SnakeGameGym(board_height, board_width, use_pygame)
+        self.game = SnakeGameGym(board_height, board_width, num_allowed_moves_since_fruit, use_pygame)
 
         self.reward_func = reward_func
         self.action_space = spaces.Discrete(4)
@@ -54,10 +57,16 @@ class SnakeEnv(gym.Env):
         # Play one frame of Snake Game
         self.game.move_snake(action)
 
+        # Increment necessary game states
+        self.game.increment_num_current_moves_since_fruit()
+
         # check collisions after move
         did_consume_fruit = self.game.check_fruit_collision()
         did_collide_wall = self.game.check_wall_collision()
         did_collide_body = self.game.check_body_collision()
+
+        # Check if snake is within threshold of allowable moves without consuming fruit
+        did_exceed_allowed_moves_no_fruit = not self.game.check_num_moves_since_fruit_valid()
 
         # Get observation after move
         observation = self.game.get_board()
@@ -67,11 +76,12 @@ class SnakeEnv(gym.Env):
             "did_consume_fruit":did_consume_fruit,
             "did_collide_wall": did_collide_wall,
             "did_collide_body": did_collide_body,
+            "did_exceed_allowed_moves_no_fruit": did_exceed_allowed_moves_no_fruit
         }
         rewards = self.reward_func(reward_dict)
 
-        # Game is over if wall collision or body collision occurred. TODO: add end done for time limit
-        done = did_collide_wall or did_collide_body
+        # Game is over if wall collision, body collision, or too many moves before consuming a fruit occurred.
+        done = did_collide_wall or did_collide_body or did_exceed_allowed_moves_no_fruit
 
         # FIXME: Figure out what to do with info. stable_baseline3 seems to require episode object
         info = {"episode": None}  
@@ -79,6 +89,11 @@ class SnakeEnv(gym.Env):
         # If there was a fruit collision during last frame, move the fruit.
         if did_consume_fruit:
             self.game.respond_to_fruit_consumption()
+            self.game.reset_num_current_moves_since_fruit()
+
+        # If game over, reset moves taken since consuming fruit to 0
+        if done:
+            self.game.reset_num_current_moves_since_fruit()
         
         if self.game.use_pygame:
             self.game.clock.tick(self.fps)

--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -14,7 +14,7 @@ class SnakeEnv(gym.Env):
     def __init__(self, 
         board_height: int = 10, 
 		board_width:int = 10,  
-		num_allowed_moves_since_fruit: int = 0,
+		max_moves_no_fruit: int = 0,
 		use_pygame: bool = True, 
 		fps: int = 3000,
         reward_func: Callable[..., float] = basic_reward_func):
@@ -23,7 +23,7 @@ class SnakeEnv(gym.Env):
 
 		board_height: the number of rows on the game board. defaults to 10.
 		board_width: the number of columns on the game board. defaults to 10.
-        num_allowed_moves_since_fruit: number of allowed consecutive moves that do not result in fruit consumption. 
+        max_moves_no_fruit: number of allowed consecutive moves that do not result in fruit consumption. 
 									   Non-positive values correspond to no limit.
 		use_pygame: boolean flag for whether or not to visualize the environment with pygame. defaults to True.
 		fps: sets the speed of the game in frames per second.
@@ -36,7 +36,7 @@ class SnakeEnv(gym.Env):
         if use_pygame:
             pygame.font.init()
             self.fps = fps
-        self.game = SnakeGameGym(board_height, board_width, num_allowed_moves_since_fruit, use_pygame)
+        self.game = SnakeGameGym(board_height, board_width, max_moves_no_fruit, use_pygame)
 
         self.reward_func = reward_func
         self.action_space = spaces.Discrete(4)
@@ -58,7 +58,7 @@ class SnakeEnv(gym.Env):
         self.game.move_snake(action)
 
         # Increment necessary game states
-        self.game.increment_num_current_moves_since_fruit()
+        self.game.increment_moves_since_fruit()
 
         # check collisions after move
         did_consume_fruit = self.game.check_fruit_collision()
@@ -66,7 +66,7 @@ class SnakeEnv(gym.Env):
         did_collide_body = self.game.check_body_collision()
 
         # Check if snake is within threshold of allowable moves without consuming fruit
-        did_exceed_allowed_moves_no_fruit = not self.game.check_num_moves_since_fruit_valid()
+        did_exceed_allowed_moves_no_fruit = not self.game.check_exceeded_max_moves()
 
         # Get observation after move
         observation = self.game.get_board()
@@ -89,11 +89,11 @@ class SnakeEnv(gym.Env):
         # If there was a fruit collision during last frame, move the fruit.
         if did_consume_fruit:
             self.game.respond_to_fruit_consumption()
-            self.game.reset_num_current_moves_since_fruit()
+            self.game.reset_moves_since_fruit()
 
         # If game over, reset moves taken since consuming fruit to 0
         if done:
-            self.game.reset_num_current_moves_since_fruit()
+            self.game.reset_moves_since_fruit()
         
         if self.game.use_pygame:
             self.game.clock.tick(self.fps)

--- a/trainTestReinforcementAlgorithm.py
+++ b/trainTestReinforcementAlgorithm.py
@@ -43,7 +43,7 @@ def trainRL(
     env_name='snake-v0', # Set gym environment name.
     board_height=10, # Set game board height.
     board_width=10, # Set game board width.
-    num_allowed_moves_since_fruit=0, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
+    max_moves_no_fruit=0, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
     visualize_training=False, # We don't want to visualize the training process.
     visualization_fps=3000, # Default to a high value for training speed if training is visualized.
     reward_function=RewardFuncs.basic_reward_func # Set reward function to be used in training. Reward functions are defined in snakeRewardFuncs.py
@@ -52,7 +52,7 @@ def trainRL(
         env_name, 
         board_height=board_height,
         board_width=board_width,
-        num_allowed_moves_since_fruit=num_allowed_moves_since_fruit,
+        max_moves_no_fruit=max_moves_no_fruit,
         use_pygame=visualize_training,
         fps=visualization_fps, 
         reward_func=reward_function
@@ -82,7 +82,7 @@ def testRL(
     env_name='snake-v0', # Set gym environment name.
     board_height=10, # Set game board height.
     board_width=10, # Set game board width.
-    num_allowed_moves_since_fruit=0, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
+    max_moves_no_fruit=0, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
     visualize_testing=True, # Set to true in order to see game moves in pygame. Should be false if run on server.
     visualization_fps=30, # Set frames per second of testing visualization.
     reward_function=RewardFuncs.basic_reward_func # Set reward function to be used in training. Reward functions are defined in snakeRewardFuncs.py
@@ -92,7 +92,7 @@ def testRL(
         env_name, 
         board_height=board_height,
         board_width=board_width, 
-        num_allowed_moves_since_fruit=num_allowed_moves_since_fruit,
+        max_moves_no_fruit=max_moves_no_fruit,
         use_pygame=visualize_testing,
         fps=visualization_fps, 
         reward_func=reward_function
@@ -167,7 +167,7 @@ def main():
 
     aparser.add_argument("--board_height", type=int, default=10)
     aparser.add_argument("--board_width", type=int, default=10)
-    aparser.add_argument("--num_allowed_moves_since_fruit", type=int, default=0)
+    aparser.add_argument("--max_moves_no_fruit", type=int, default=0)
     aparser.add_argument("--visualize_training", type=bool, default=False)
     aparser.add_argument("--visualize_testing", type=bool, default=True)
     aparser.add_argument("--visualization_fps", type=int, default=30)
@@ -191,7 +191,7 @@ def main():
         args.env_name,
         args.board_height,
         args.board_width,
-        args.num_allowed_moves_since_fruit,
+        args.max_moves_no_fruit,
         args.visualize_training,
         args.visualization_fps,
         reward_function
@@ -204,7 +204,7 @@ def main():
         args.env_name,
         args.board_height,
         args.board_width,
-        args.num_allowed_moves_since_fruit,
+        args.max_moves_no_fruit,
         args.visualize_testing,
         args.visualization_fps,
         reward_function)

--- a/trainTestReinforcementAlgorithm.py
+++ b/trainTestReinforcementAlgorithm.py
@@ -43,7 +43,7 @@ def trainRL(
     env_name='snake-v0', # Set gym environment name.
     board_height=10, # Set game board height.
     board_width=10, # Set game board width.
-    num_allowed_moves_since_fruit=25, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
+    num_allowed_moves_since_fruit=0, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
     visualize_training=False, # We don't want to visualize the training process.
     visualization_fps=3000, # Default to a high value for training speed if training is visualized.
     reward_function=RewardFuncs.basic_reward_func # Set reward function to be used in training. Reward functions are defined in snakeRewardFuncs.py
@@ -82,7 +82,7 @@ def testRL(
     env_name='snake-v0', # Set gym environment name.
     board_height=10, # Set game board height.
     board_width=10, # Set game board width.
-    num_allowed_moves_since_fruit=25, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
+    num_allowed_moves_since_fruit=0, # Set number of allowed moves without fruit consumption before ending the game. Any non-poitive number corresponds to no limit.
     visualize_testing=True, # Set to true in order to see game moves in pygame. Should be false if run on server.
     visualization_fps=30, # Set frames per second of testing visualization.
     reward_function=RewardFuncs.basic_reward_func # Set reward function to be used in training. Reward functions are defined in snakeRewardFuncs.py

--- a/trainTestReinforcementAlgorithm.py
+++ b/trainTestReinforcementAlgorithm.py
@@ -42,7 +42,8 @@ def trainRL(
     train_timesteps: int,
     env_name: str,
     board_height: int,
-    board_width: int, 
+    board_width: int,
+    num_allowed_moves_since_fruit: int,
     visualize_training: bool,
     visualization_fps: int, 
     reward_function: Callable[..., float]
@@ -50,7 +51,8 @@ def trainRL(
     env = gym.make(
         env_name, 
         board_height=board_height,
-        board_width=board_width, 
+        board_width=board_width,
+        num_allowed_moves_since_fruit=num_allowed_moves_since_fruit,
         use_pygame=visualize_training,
         fps=visualization_fps, 
         reward_func=reward_function
@@ -79,7 +81,8 @@ def testRL(
     test_timesteps: int,
     env_name: str,
     board_height: int,
-    board_width: int, 
+    board_width: int,
+    num_allowed_moves_since_fruit: int,
     visualize_testing: bool,
     visualization_fps: int, 
     reward_function: Callable[..., float]
@@ -89,6 +92,7 @@ def testRL(
         env_name, 
         board_height=board_height,
         board_width=board_width, 
+        num_allowed_moves_since_fruit=num_allowed_moves_since_fruit,
         use_pygame=visualize_testing,
         fps=visualization_fps, 
         reward_func=reward_function
@@ -152,6 +156,10 @@ env_name = 'snake-v0'
 board_height = 10
 board_width = 10
 
+# Set number of allowed moves without fruit consumption before ending the game.
+# Any non-poitive number corresponds to no limit.
+num_allowed_moves_since_fruit = 25
+
 # Set visualization arguments
 visualize_training = False # We don't want to visualize the training process
 visualize_testing = True # Set to true in order to see game moves in pygame. Should be false if run on server.
@@ -159,7 +167,8 @@ visualization_fps = 30
 
 # Set reward function to be used in training 
 # Reward functions are defined in snakeRewardFuncs.py
-reward_function = basic_reward_func 
+reward_function = basic_reward_func
+# reward_function = basic_reward_func_with_move_ceiling 
 
 
 # %% [markdown]
@@ -167,10 +176,10 @@ reward_function = basic_reward_func
 # To run in the notebook, uncomment the following three lines:
 
 # %%
-model = trainRL(train_timesteps, env_name, board_height, board_width, visualize_training, visualization_fps, reward_function)
-scores = testRL(model, test_timesteps, env_name, board_height, board_width, visualize_testing, visualization_fps, reward_function)
-analyzeRL(scores)
-saveRL(model)
+# model = trainRL(train_timesteps, env_name, board_height, board_width, num_allowed_moves_since_fruit, visualize_training, visualization_fps, reward_function)
+# scores = testRL(model, test_timesteps, env_name, board_height, board_width, num_allowed_moves_since_fruit, visualize_testing, visualization_fps, reward_function)
+# analyzeRL(scores)
+# saveRL(model)
 
 # %% [markdown]
 # ## Run on commandline
@@ -183,10 +192,11 @@ def main():
     aparser.add_argument("--env_name", type=str, default="snake-v0")
 
     aparser.add_argument("--train_timesteps", type=int, default=1000)
-    
     aparser.add_argument("--test_timesteps", type=int, default=100)
+
     aparser.add_argument("--board_height", type=int, default=10)
     aparser.add_argument("--board_width", type=int, default=10)
+    aparser.add_argument("--num_allowed_moves_since_fruit", type=int, default=0)
     aparser.add_argument("--visualize_training", type=bool, default=False)
     aparser.add_argument("--visualize_testing", type=bool, default=True)
     aparser.add_argument("--visualization_fps", type=int, default=30)
@@ -206,6 +216,7 @@ def main():
         args.env_name,
         args.board_height,
         args.board_width,
+        args.num_allowed_moves_since_fruit,
         args.visualize_training,
         args.visualization_fps,
         args.reward_function
@@ -218,6 +229,7 @@ def main():
         args.env_name,
         args.board_height,
         args.board_width,
+        args.num_allowed_moves_since_fruit,
         args.visualize_testing,
         args.visualization_fps,
         args.reward_function)


### PR DESCRIPTION
This PR adds the ability to "kill" the snake agent after `n` moves without a fruit consumption by specifying the `num_allowed_moves_since_fruit` argument in `SnakeGameGym`. Any non-positive number corresponds to no limit.

In addition, it adds a `basic_reward_func_with_move_ceiling` reward function that can be used used to punish the snake for failing to consume a fruit within the specified number of moves.